### PR TITLE
feat(profile): add secrets handling to kubernetes and machine init profiles

### DIFF
--- a/charmcraft/templates/init-kubernetes/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-kubernetes/charmcraft.yaml.j2
@@ -48,6 +48,21 @@ config:
         Acceptable values are: "info", "debug", "warning", "error" and "critical"
       default: "info"
       type: string
+    # A secret config option for a user-provided API token.
+    # Operator workflow:
+    #   juju add-secret my-api-token token=<value>
+    #   juju grant-secret <id> {{ name }}
+    #   juju config {{ name }} api-token=<id>
+    # See https://documentation.ubuntu.com/juju/3.6/howto/manage-secrets/
+    api-token:
+      description: |
+        URI of a Juju user secret containing the API token for the workload.
+        The secret must have a 'token' key.
+
+        Create the secret: juju add-secret my-api-token token=<value>
+        Grant access:      juju grant-secret <id> {{ name }}
+        Set this option:   juju config {{ name }} api-token=<id>
+      type: secret
 
 # Your workload's containers.
 # https://documentation.ubuntu.com/charmcraft/stable/reference/files/charmcraft-yaml-file/#containers

--- a/charmcraft/templates/init-kubernetes/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-kubernetes/charmcraft.yaml.j2
@@ -49,10 +49,6 @@ config:
       default: "info"
       type: string
     # A secret config option for a user-provided API token.
-    # Operator workflow:
-    #   juju add-secret my-api-token token=<value>
-    #   juju grant-secret <id> {{ name }}
-    #   juju config {{ name }} api-token=<id>
     # See https://documentation.ubuntu.com/juju/3.6/howto/manage-secrets/
     api-token:
       description: |

--- a/charmcraft/templates/init-kubernetes/src/charm.py.j2
+++ b/charmcraft/templates/init-kubernetes/src/charm.py.j2
@@ -4,10 +4,10 @@
 
 """Charm the application."""
 
+import datetime
 import logging
 import secrets
 import time
-from datetime import timedelta
 
 import ops
 
@@ -100,7 +100,7 @@ class {{ class_name }}(ops.CharmBase):
                 {"password": secrets.token_hex(32)},
                 label=APP_SECRET_LABEL,
                 rotate=ops.SecretRotate.MONTHLY,
-                expire=timedelta(days=90),
+                expire=datetime.timedelta(days=90),
             )
 
     def _on_secret_rotate(self, event: ops.SecretRotateEvent):

--- a/charmcraft/templates/init-kubernetes/src/charm.py.j2
+++ b/charmcraft/templates/init-kubernetes/src/charm.py.j2
@@ -5,7 +5,9 @@
 """Charm the application."""
 
 import logging
+import secrets
 import time
+from datetime import timedelta
 
 import ops
 
@@ -15,6 +17,7 @@ import {{ workload_module }}
 logger = logging.getLogger(__name__)
 
 SERVICE_NAME = "some-service"  # Name of Pebble service that runs in the workload container.
+APP_SECRET_LABEL = "workload-password"  # Label for the app-managed workload secret.
 
 
 class {{ class_name }}(ops.CharmBase):
@@ -23,6 +26,9 @@ class {{ class_name }}(ops.CharmBase):
     def __init__(self, framework: ops.Framework):
         super().__init__(framework)
         framework.observe(self.on["some_container"].pebble_ready, self._on_pebble_ready)
+        framework.observe(self.on.config_changed, self._on_config_changed)
+        framework.observe(self.on.secret_rotate, self._on_secret_rotate)
+        framework.observe(self.on.secret_expired, self._on_secret_expired)
         self.container = self.unit.get_container("some-container")
 
     def _on_pebble_ready(self, event: ops.PebbleReadyEvent):
@@ -49,7 +55,49 @@ class {{ class_name }}(ops.CharmBase):
         version = {{ workload_module }}.get_version()
         if version is not None:
             self.unit.set_workload_version(version)
+        # Create the app-managed workload secret on first start (leader only).
+        if self.unit.is_leader():
+            self._ensure_app_secret()
         self.unit.status = ops.ActiveStatus()
+
+    def _on_config_changed(self, event: ops.ConfigChangedEvent):
+        """Handle config-changed event — resolve the user-provided api-token secret."""
+        api_token_id = self.config.get("api-token")
+        if not api_token_id:
+            return
+        try:
+            secret = self.model.get_secret(id=api_token_id)
+            content = secret.get_content(refresh=True)
+            token = content.get("token", "")
+            # Use 'token' to configure your workload, for example:
+            # {{ workload_module }}.configure(api_token=token)
+            logger.info("api-token resolved (%d chars); reconfiguring workload", len(token))
+        except ops.SecretNotFoundError:
+            self.unit.status = ops.BlockedStatus("api-token secret not found or not granted")
+            return
+        self.unit.status = ops.ActiveStatus()
+
+    def _ensure_app_secret(self) -> ops.Secret:
+        """Get or create the app-managed workload password (idempotent, leader only)."""
+        try:
+            return self.model.get_secret(label=APP_SECRET_LABEL)
+        except ops.SecretNotFoundError:
+            return self.app.add_secret(
+                {"password": secrets.token_hex(32)},
+                label=APP_SECRET_LABEL,
+                rotate=ops.SecretRotate.MONTHLY,
+                expire=timedelta(days=90),
+            )
+
+    def _on_secret_rotate(self, event: ops.SecretRotateEvent):
+        """Handle secret-rotate event — generate a fresh workload password."""
+        if event.secret.label == APP_SECRET_LABEL:
+            event.secret.set_content({"password": secrets.token_hex(32)})
+
+    def _on_secret_expired(self, event: ops.SecretExpiredEvent):
+        """Handle secret-expired event — remove the expired revision."""
+        if event.secret.label == APP_SECRET_LABEL:
+            event.secret.remove_revision(event.revision)
 
     def is_ready(self) -> bool:
         """Check whether the workload is ready to use."""

--- a/charmcraft/templates/init-kubernetes/src/charm.py.j2
+++ b/charmcraft/templates/init-kubernetes/src/charm.py.j2
@@ -17,6 +17,7 @@ import {{ workload_module }}
 logger = logging.getLogger(__name__)
 
 SERVICE_NAME = "some-service"  # Name of Pebble service that runs in the workload container.
+API_TOKEN_LABEL = "api-token"  # Label for the user-provided secret named in charm config.
 APP_SECRET_LABEL = "workload-password"  # Label for the app-managed workload secret.
 
 
@@ -27,8 +28,10 @@ class {{ class_name }}(ops.CharmBase):
         super().__init__(framework)
         framework.observe(self.on["some_container"].pebble_ready, self._on_pebble_ready)
         framework.observe(self.on.config_changed, self._on_config_changed)
+        framework.observe(self.on.secret_changed, self._on_secret_changed)
         framework.observe(self.on.secret_rotate, self._on_secret_rotate)
         framework.observe(self.on.secret_expired, self._on_secret_expired)
+        framework.observe(self.on.secret_remove, self._on_secret_remove)
         self.container = self.unit.get_container("some-container")
 
     def _on_pebble_ready(self, event: ops.PebbleReadyEvent):
@@ -61,20 +64,31 @@ class {{ class_name }}(ops.CharmBase):
         self.unit.status = ops.ActiveStatus()
 
     def _on_config_changed(self, event: ops.ConfigChangedEvent):
-        """Handle config-changed event — resolve the user-provided api-token secret."""
+        """Handle config-changed event — the api-token config might name a different secret."""
+        self._configure_api_token()
+
+    def _on_secret_changed(self, event: ops.SecretChangedEvent):
+        """Handle secret-changed event — the api-token secret has a new revision."""
+        if event.secret.label == API_TOKEN_LABEL:
+            self._configure_api_token()
+
+    def _configure_api_token(self) -> None:
+        """Read the user-provided api-token secret and configure the workload with it."""
         api_token_id = self.config.get("api-token")
         if not api_token_id:
             return
         try:
-            secret = self.model.get_secret(id=api_token_id)
+            # Attaching a label lets the secret-changed handler recognise this secret.
+            secret = self.model.get_secret(id=api_token_id, label=API_TOKEN_LABEL)
+            # 'refresh' tells Juju to start tracking the latest revision.
             content = secret.get_content(refresh=True)
-            token = content.get("token", "")
-            # Use 'token' to configure your workload, for example:
-            # {{ workload_module }}.configure(api_token=token)
-            logger.info("api-token resolved (%d chars); reconfiguring workload", len(token))
         except ops.SecretNotFoundError:
             self.unit.status = ops.BlockedStatus("api-token secret not found or not granted")
             return
+        token = content.get("token", "")
+        # Use 'token' to configure your workload, for example:
+        # {{ workload_module }}.configure(api_token=token)
+        logger.info("api-token resolved (%d chars); reconfiguring workload", len(token))
         self.unit.status = ops.ActiveStatus()
 
     def _ensure_app_secret(self) -> ops.Secret:
@@ -90,14 +104,26 @@ class {{ class_name }}(ops.CharmBase):
             )
 
     def _on_secret_rotate(self, event: ops.SecretRotateEvent):
-        """Handle secret-rotate event — generate a fresh workload password."""
+        """Handle secret-rotate event — the rotation policy says it's time for a new password."""
         if event.secret.label == APP_SECRET_LABEL:
-            event.secret.set_content({"password": secrets.token_hex(32)})
+            self._set_new_password(event.secret)
 
     def _on_secret_expired(self, event: ops.SecretExpiredEvent):
-        """Handle secret-expired event — remove the expired revision."""
+        """Handle secret-expired event — the current password must not be used any more."""
         if event.secret.label == APP_SECRET_LABEL:
-            event.secret.remove_revision(event.revision)
+            self._set_new_password(event.secret)
+
+    def _set_new_password(self, secret: ops.Secret) -> None:
+        """Add a new revision of the app-managed workload password."""
+        # Don't remove the old revision here: other units might still be using it.
+        # Juju emits secret-remove once no unit is tracking it any more.
+        secret.set_content({"password": secrets.token_hex(32)})
+
+    def _on_secret_remove(self, event: ops.SecretRemoveEvent):
+        """Handle secret-remove event — no unit is using this revision any more."""
+        # Without this, every rotation leaves another revision behind.
+        if event.secret.label == APP_SECRET_LABEL:
+            event.remove_revision()
 
     def is_ready(self) -> bool:
         """Check whether the workload is ready to use."""

--- a/charmcraft/templates/init-kubernetes/tests/integration/test_charm.py.j2
+++ b/charmcraft/templates/init-kubernetes/tests/integration/test_charm.py.j2
@@ -9,6 +9,7 @@
 
 import logging
 import pathlib
+import subprocess
 
 import jubilant
 import pytest
@@ -29,11 +30,40 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     juju.wait(jubilant.all_active)
 
 
+def test_app_managed_secret_created(juju: jubilant.Juju):
+    """Check that the app-managed workload-password secret is visible after deployment."""
+    # The charm creates this secret on pebble-ready (leader unit).
+    # 'juju list-secrets' shows all secrets the current model user can see.
+    result = subprocess.check_output(["juju", "list-secrets", "--format=yaml"], text=True)
+    assert "workload-password" in result, (
+        "Expected the charm to create a 'workload-password' app secret on start. "
+        "Check that the leader unit ran pebble-ready successfully."
+    )
+
+
+def test_user_secret(juju: jubilant.Juju):
+    """Test that a user-provided api-token secret is resolved by the charm."""
+    # Create a user secret with a 'token' key and set it as config.
+    secret_uri = subprocess.check_output(
+        ["juju", "add-secret", "test-api-token", "token=testvalue123"],
+        text=True,
+    ).strip()
+    subprocess.check_call(["juju", "grant-secret", secret_uri, "{{ name }}"])
+    juju.config("{{ name }}", {"api-token": secret_uri})
+    juju.wait(jubilant.all_active)
+
+    status = juju.status()
+    assert status.apps["{{ name }}"].is_active
+
+    # Clean up: reset the config option so subsequent tests start clean.
+    juju.config("{{ name }}", reset=["api-token"])
+
+
 # If you implement {{ workload_module }}.get_version in the charm source,
 # remove the @pytest.mark.skip line to enable this test.
 # Alternatively, remove this test if you don't need it.
 @pytest.mark.skip(reason="{{ workload_module }}.get_version is not implemented")
-def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
+def test_workload_version_is_set(juju: jubilant.Juju):
     """Check that the correct version of the workload is running."""
     version = juju.status().apps["{{ name }}"].version
     assert version == "3.14"  # Replace 3.14 by the expected version of the workload.

--- a/charmcraft/templates/init-kubernetes/tests/integration/test_charm.py.j2
+++ b/charmcraft/templates/init-kubernetes/tests/integration/test_charm.py.j2
@@ -29,7 +29,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     juju.wait(jubilant.all_active)
 
 
-def test_app_managed_secret_created(juju: jubilant.Juju):
+def test_app_managed_secret_created(charm: pathlib.Path, juju: jubilant.Juju):
     """Check that the charm created the app-managed workload password on pebble-ready."""
     labels = [secret.label for secret in juju.secrets()]
     assert "workload-password" in labels, (
@@ -38,7 +38,7 @@ def test_app_managed_secret_created(juju: jubilant.Juju):
     )
 
 
-def test_user_secret(juju: jubilant.Juju):
+def test_user_secret(charm: pathlib.Path, juju: jubilant.Juju):
     """Test that the charm resolves a user-provided api-token secret."""
     # Create a user secret with a 'token' key, grant the charm access, and
     # point the charm at it.
@@ -66,7 +66,7 @@ def test_user_secret(juju: jubilant.Juju):
 # remove the @pytest.mark.skip line to enable this test.
 # Alternatively, remove this test if you don't need it.
 @pytest.mark.skip(reason="{{ workload_module }}.get_version is not implemented")
-def test_workload_version_is_set(juju: jubilant.Juju):
+def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
     """Check that the correct version of the workload is running."""
     version = juju.status().apps["{{ name }}"].version
     assert version == "3.14"  # Replace 3.14 by the expected version of the workload.

--- a/charmcraft/templates/init-kubernetes/tests/integration/test_charm.py.j2
+++ b/charmcraft/templates/init-kubernetes/tests/integration/test_charm.py.j2
@@ -9,7 +9,6 @@
 
 import logging
 import pathlib
-import subprocess
 
 import jubilant
 import pytest
@@ -31,29 +30,33 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 
 
 def test_app_managed_secret_created(juju: jubilant.Juju):
-    """Check that the app-managed workload-password secret is visible after deployment."""
-    # The charm creates this secret on pebble-ready (leader unit).
-    # 'juju list-secrets' shows all secrets the current model user can see.
-    result = subprocess.check_output(["juju", "list-secrets", "--format=yaml"], text=True)
-    assert "workload-password" in result, (
+    """Check that the charm created the app-managed workload password on pebble-ready."""
+    labels = [secret.label for secret in juju.secrets()]
+    assert "workload-password" in labels, (
         "Expected the charm to create a 'workload-password' app secret on start. "
         "Check that the leader unit ran pebble-ready successfully."
     )
 
 
 def test_user_secret(juju: jubilant.Juju):
-    """Test that a user-provided api-token secret is resolved by the charm."""
-    # Create a user secret with a 'token' key and set it as config.
-    secret_uri = subprocess.check_output(
-        ["juju", "add-secret", "test-api-token", "token=testvalue123"],
-        text=True,
-    ).strip()
-    subprocess.check_call(["juju", "grant-secret", secret_uri, "{{ name }}"])
+    """Test that the charm resolves a user-provided api-token secret."""
+    # Create a user secret with a 'token' key, grant the charm access, and
+    # point the charm at it.
+    secret_uri = juju.add_secret("test-api-token", {"token": "shortvalue"})
+    juju.grant_secret(secret_uri, "{{ name }}")
     juju.config("{{ name }}", {"api-token": secret_uri})
     juju.wait(jubilant.all_active)
 
-    status = juju.status()
-    assert status.apps["{{ name }}"].is_active
+    # The charm logs the length of the token it resolved.
+    assert "api-token resolved (10 chars)" in juju.debug_log()
+
+    # Act — add a new revision of the same secret. Juju notifies the charm with
+    # a secret-changed event, and the charm re-reads the content.
+    juju.update_secret(secret_uri, {"token": "a-much-longer-token-value"})
+    juju.wait(jubilant.all_active)
+
+    # Assert — the charm picked up the new revision, not the original one.
+    assert "api-token resolved (25 chars)" in juju.debug_log()
 
     # Clean up: reset the config option so subsequent tests start clean.
     juju.config("{{ name }}", reset=["api-token"])

--- a/charmcraft/templates/init-kubernetes/tests/unit/test_charm.py.j2
+++ b/charmcraft/templates/init-kubernetes/tests/unit/test_charm.py.j2
@@ -7,7 +7,7 @@ import ops
 import pytest
 from ops import testing
 
-from charm import SERVICE_NAME, {{ class_name }}
+from charm import APP_SECRET_LABEL, SERVICE_NAME, {{ class_name }}
 
 CHECK_NAME = "service-ready"  # Name of Pebble check in the mock workload container.
 
@@ -43,22 +43,27 @@ def mock_get_version():
     return "1.0.0"
 
 
-def test_pebble_ready(monkeypatch: pytest.MonkeyPatch):
-    """Test that the charm has the correct state after handling the pebble-ready event."""
-    # Arrange:
-    ctx = testing.Context({{ class_name }})
+def make_container(check_status: ops.pebble.CheckStatus) -> testing.Container:
+    """Build a test container with the given check status."""
     check_in = testing.CheckInfo(
         CHECK_NAME,
         level=ops.pebble.CheckLevel.READY,
-        status=ops.pebble.CheckStatus.UP,  # Simulate the Pebble check passing.
+        status=check_status,
     )
-    container_in = testing.Container(
+    return testing.Container(
         "some-container",
         can_connect=True,
         layers={"base": MOCK_LAYER},
         service_statuses={SERVICE_NAME: ops.pebble.ServiceStatus.INACTIVE},
         check_infos={check_in},
     )
+
+
+def test_pebble_ready(monkeypatch: pytest.MonkeyPatch):
+    """Test that the charm has the correct state after handling the pebble-ready event."""
+    # Arrange:
+    ctx = testing.Context({{ class_name }})
+    container_in = make_container(ops.pebble.CheckStatus.UP)
     state_in = testing.State(containers={container_in})
     monkeypatch.setattr("charm.{{ workload_module }}.get_version", mock_get_version)
 
@@ -76,20 +81,137 @@ def test_pebble_ready_service_not_ready():
     """Test that the charm raises an error if the workload isn't ready after Pebble starts it."""
     # Arrange:
     ctx = testing.Context({{ class_name }})
-    check_in = testing.CheckInfo(
-        CHECK_NAME,
-        level=ops.pebble.CheckLevel.READY,
-        status=ops.pebble.CheckStatus.DOWN,  # Simulate the Pebble check failing.
-    )
-    container_in = testing.Container(
-        "some-container",
-        can_connect=True,
-        layers={"base": MOCK_LAYER},
-        service_statuses={SERVICE_NAME: ops.pebble.ServiceStatus.INACTIVE},
-        check_infos={check_in},
-    )
+    container_in = make_container(ops.pebble.CheckStatus.DOWN)
     state_in = testing.State(containers={container_in})
 
     # Act & assert:
     with pytest.raises(testing.errors.UncaughtCharmError):
         ctx.run(ctx.on.pebble_ready(container_in), state_in)
+
+
+def test_pebble_ready_creates_app_secret(monkeypatch: pytest.MonkeyPatch):
+    """Test that the charm creates an app-managed workload secret on pebble-ready (leader)."""
+    # Arrange:
+    ctx = testing.Context({{ class_name }})
+    container_in = make_container(ops.pebble.CheckStatus.UP)
+    state_in = testing.State(containers={container_in}, leader=True)
+    monkeypatch.setattr("charm.{{ workload_module }}.get_version", mock_get_version)
+
+    # Act:
+    state_out = ctx.run(ctx.on.pebble_ready(container_in), state_in)
+
+    # Assert — the app-owned secret should appear in the output state with a 'password' key:
+    app_secrets = [s for s in state_out.secrets if s.label == APP_SECRET_LABEL]
+    assert len(app_secrets) == 1
+    assert app_secrets[0].latest_content is not None
+    assert "password" in app_secrets[0].latest_content
+
+
+def test_pebble_ready_app_secret_already_exists(monkeypatch: pytest.MonkeyPatch):
+    """Test that pebble-ready is idempotent when the app secret already exists."""
+    # Arrange:
+    ctx = testing.Context({{ class_name }})
+    container_in = make_container(ops.pebble.CheckStatus.UP)
+    existing_secret = testing.Secret(
+        tracked_content={"password": "existing-password"},
+        label=APP_SECRET_LABEL,
+        owner="app",
+    )
+    state_in = testing.State(containers={container_in}, leader=True, secrets={existing_secret})
+    monkeypatch.setattr("charm.{{ workload_module }}.get_version", mock_get_version)
+
+    # Act:
+    state_out = ctx.run(ctx.on.pebble_ready(container_in), state_in)
+
+    # Assert — the existing secret is still present; no extra secret was created:
+    app_secrets = [s for s in state_out.secrets if s.label == APP_SECRET_LABEL]
+    assert len(app_secrets) == 1
+
+
+def test_config_changed_with_api_token():
+    """Test that config-changed resolves a user-provided secret and goes active."""
+    # Arrange:
+    ctx = testing.Context({{ class_name }})
+    secret = testing.Secret(
+        tracked_content={"token": "my-secret-api-token"},
+        id="secret:abcdef123456",
+        owner=None,  # user-owned secret (not app- or unit-owned)
+    )
+    state_in = testing.State(
+        secrets={secret},
+        config={"api-token": secret.id},
+    )
+
+    # Act:
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    # Assert:
+    assert state_out.unit_status == testing.ActiveStatus()
+
+
+def test_config_changed_api_token_not_found():
+    """Test that config-changed blocks when the secret URI is not accessible."""
+    # Arrange:
+    ctx = testing.Context({{ class_name }})
+    state_in = testing.State(
+        config={"api-token": "secret:doesnotexist"},
+        # No matching secret in state — simulates the secret not being granted.
+    )
+
+    # Act:
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    # Assert:
+    assert isinstance(state_out.unit_status, testing.BlockedStatus)
+
+
+def test_config_changed_no_token():
+    """Test that config-changed without api-token set does nothing."""
+    # Arrange:
+    ctx = testing.Context({{ class_name }})
+    state_in = testing.State()
+
+    # Act:
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    # Assert — status unchanged (charm hasn't done anything yet):
+    assert not isinstance(state_out.unit_status, testing.BlockedStatus)
+
+
+def test_secret_rotate():
+    """Test that secret-rotate generates a new revision of the workload password."""
+    # Arrange:
+    ctx = testing.Context({{ class_name }})
+    secret = testing.Secret(
+        tracked_content={"password": "old-password"},
+        label=APP_SECRET_LABEL,
+        owner="app",
+    )
+    state_in = testing.State(secrets={secret}, leader=True)
+
+    # Act:
+    state_out = ctx.run(ctx.on.secret_rotate(secret), state_in)
+
+    # Assert — a new revision with a different password should have been added:
+    out_secret = state_out.get_secret(label=APP_SECRET_LABEL)
+    assert out_secret.latest_content is not None
+    assert "password" in out_secret.latest_content
+    assert out_secret.latest_content["password"] != "old-password"
+
+
+def test_secret_expired():
+    """Test that secret-expired removes the expired revision without error."""
+    # Arrange:
+    ctx = testing.Context({{ class_name }})
+    secret = testing.Secret(
+        tracked_content={"password": "current-password"},
+        label=APP_SECRET_LABEL,
+        owner="app",
+    )
+    state_in = testing.State(secrets={secret}, leader=True)
+
+    # Act — simulate the tracked revision expiring:
+    state_out = ctx.run(ctx.on.secret_expired(secret, revision=1), state_in)
+
+    # Assert — the charm should not have errored or blocked:
+    assert not isinstance(state_out.unit_status, testing.BlockedStatus)

--- a/charmcraft/templates/init-kubernetes/tests/unit/test_charm.py.j2
+++ b/charmcraft/templates/init-kubernetes/tests/unit/test_charm.py.j2
@@ -7,7 +7,7 @@ import ops
 import pytest
 from ops import testing
 
-from charm import APP_SECRET_LABEL, SERVICE_NAME, {{ class_name }}
+from charm import API_TOKEN_LABEL, APP_SECRET_LABEL, SERVICE_NAME, {{ class_name }}
 
 CHECK_NAME = "service-ready"  # Name of Pebble check in the mock workload container.
 
@@ -134,7 +134,6 @@ def test_config_changed_with_api_token():
     ctx = testing.Context({{ class_name }})
     secret = testing.Secret(
         tracked_content={"token": "my-secret-api-token"},
-        id="secret:abcdef123456",
         owner=None,  # user-owned secret (not app- or unit-owned)
     )
     state_in = testing.State(
@@ -154,7 +153,7 @@ def test_config_changed_api_token_not_found():
     # Arrange:
     ctx = testing.Context({{ class_name }})
     state_in = testing.State(
-        config={"api-token": "secret:doesnotexist"},
+        config={"api-token": "secret:doesnotexist00000000"},
         # No matching secret in state — simulates the secret not being granted.
     )
 
@@ -200,11 +199,11 @@ def test_secret_rotate():
 
 
 def test_secret_expired():
-    """Test that secret-expired removes the expired revision without error."""
+    """Test that secret-expired replaces the expired password with a new revision."""
     # Arrange:
     ctx = testing.Context({{ class_name }})
     secret = testing.Secret(
-        tracked_content={"password": "current-password"},
+        tracked_content={"password": "expired-password"},
         label=APP_SECRET_LABEL,
         owner="app",
     )
@@ -213,5 +212,49 @@ def test_secret_expired():
     # Act — simulate the tracked revision expiring:
     state_out = ctx.run(ctx.on.secret_expired(secret, revision=1), state_in)
 
-    # Assert — the charm should not have errored or blocked:
-    assert not isinstance(state_out.unit_status, testing.BlockedStatus)
+    # Assert — a new revision should have been added, not the old one removed:
+    out_secret = state_out.get_secret(label=APP_SECRET_LABEL)
+    assert out_secret.latest_content is not None
+    assert out_secret.latest_content["password"] != "expired-password"
+
+
+def test_secret_changed_new_api_token_revision():
+    """Test that the charm picks up a new revision of the user-provided api-token."""
+    # Arrange:
+    ctx = testing.Context({{ class_name }})
+    secret = testing.Secret(
+        tracked_content={"token": "old-api-token"},
+        latest_content={"token": "new-api-token"},
+        label=API_TOKEN_LABEL,
+        owner=None,  # user-owned secret (not app- or unit-owned)
+    )
+    state_in = testing.State(secrets={secret}, config={"api-token": secret.id})
+
+    # Act:
+    state_out = ctx.run(ctx.on.secret_changed(secret), state_in)
+
+    # Assert — the charm refreshed, so it now tracks the latest revision:
+    out_secret = state_out.get_secret(label=API_TOKEN_LABEL)
+    assert out_secret.tracked_content == {"token": "new-api-token"}
+    assert state_out.unit_status == testing.ActiveStatus()
+
+
+def test_secret_remove():
+    """Test that secret-remove cleans up a revision that no unit is using."""
+    # Arrange — rotate twice, so that revision 2 is neither the oldest revision
+    # nor the newest one:
+    ctx = testing.Context({{ class_name }})
+    secret = testing.Secret(
+        tracked_content={"password": "first-password"},
+        label=APP_SECRET_LABEL,
+        owner="app",
+    )
+    state = testing.State(secrets={secret}, leader=True)
+    for _ in range(2):
+        state = ctx.run(ctx.on.secret_rotate(state.get_secret(label=APP_SECRET_LABEL)), state)
+
+    # Act — Juju reports that revision 2 is no longer tracked by any unit:
+    ctx.run(ctx.on.secret_remove(state.get_secret(label=APP_SECRET_LABEL), revision=2), state)
+
+    # Assert — the charm asked Juju to remove that revision:
+    assert ctx.removed_secret_revisions == [2]

--- a/charmcraft/templates/init-machine/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-machine/charmcraft.yaml.j2
@@ -47,3 +47,18 @@ config:
         Acceptable values are: "info", "debug", "warning", "error" and "critical"
       default: "info"
       type: string
+    # A secret config option for a user-provided API token.
+    # Operator workflow:
+    #   juju add-secret my-api-token token=<value>
+    #   juju grant-secret <id> {{ name }}
+    #   juju config {{ name }} api-token=<id>
+    # See https://documentation.ubuntu.com/juju/3.6/howto/manage-secrets/
+    api-token:
+      description: |
+        URI of a Juju user secret containing the API token for the workload.
+        The secret must have a 'token' key.
+
+        Create the secret: juju add-secret my-api-token token=<value>
+        Grant access:      juju grant-secret <id> {{ name }}
+        Set this option:   juju config {{ name }} api-token=<id>
+      type: secret

--- a/charmcraft/templates/init-machine/charmcraft.yaml.j2
+++ b/charmcraft/templates/init-machine/charmcraft.yaml.j2
@@ -48,10 +48,6 @@ config:
       default: "info"
       type: string
     # A secret config option for a user-provided API token.
-    # Operator workflow:
-    #   juju add-secret my-api-token token=<value>
-    #   juju grant-secret <id> {{ name }}
-    #   juju config {{ name }} api-token=<id>
     # See https://documentation.ubuntu.com/juju/3.6/howto/manage-secrets/
     api-token:
       description: |

--- a/charmcraft/templates/init-machine/src/charm.py.j2
+++ b/charmcraft/templates/init-machine/src/charm.py.j2
@@ -15,6 +15,7 @@ import {{ workload_module }}
 
 logger = logging.getLogger(__name__)
 
+API_TOKEN_LABEL = "api-token"  # Label for the user-provided secret named in charm config.
 APP_SECRET_LABEL = "workload-password"  # Label for the app-managed workload secret.
 
 
@@ -26,8 +27,10 @@ class {{ class_name }}(ops.CharmBase):
         framework.observe(self.on.install, self._on_install)
         framework.observe(self.on.start, self._on_start)
         framework.observe(self.on.config_changed, self._on_config_changed)
+        framework.observe(self.on.secret_changed, self._on_secret_changed)
         framework.observe(self.on.secret_rotate, self._on_secret_rotate)
         framework.observe(self.on.secret_expired, self._on_secret_expired)
+        framework.observe(self.on.secret_remove, self._on_secret_remove)
 
     def _on_install(self, event: ops.InstallEvent):
         """Install the workload on the machine."""
@@ -46,20 +49,31 @@ class {{ class_name }}(ops.CharmBase):
         self.unit.status = ops.ActiveStatus()
 
     def _on_config_changed(self, event: ops.ConfigChangedEvent):
-        """Handle config-changed event — resolve the user-provided api-token secret."""
+        """Handle config-changed event — the api-token config might name a different secret."""
+        self._configure_api_token()
+
+    def _on_secret_changed(self, event: ops.SecretChangedEvent):
+        """Handle secret-changed event — the api-token secret has a new revision."""
+        if event.secret.label == API_TOKEN_LABEL:
+            self._configure_api_token()
+
+    def _configure_api_token(self) -> None:
+        """Read the user-provided api-token secret and configure the workload with it."""
         api_token_id = self.config.get("api-token")
         if not api_token_id:
             return
         try:
-            secret = self.model.get_secret(id=api_token_id)
+            # Attaching a label lets the secret-changed handler recognise this secret.
+            secret = self.model.get_secret(id=api_token_id, label=API_TOKEN_LABEL)
+            # 'refresh' tells Juju to start tracking the latest revision.
             content = secret.get_content(refresh=True)
-            token = content.get("token", "")
-            # Use 'token' to configure your workload, for example:
-            # {{ workload_module }}.configure(api_token=token)
-            logger.info("api-token resolved (%d chars); reconfiguring workload", len(token))
         except ops.SecretNotFoundError:
             self.unit.status = ops.BlockedStatus("api-token secret not found or not granted")
             return
+        token = content.get("token", "")
+        # Use 'token' to configure your workload, for example:
+        # {{ workload_module }}.configure(api_token=token)
+        logger.info("api-token resolved (%d chars); reconfiguring workload", len(token))
         self.unit.status = ops.ActiveStatus()
 
     def _ensure_app_secret(self) -> ops.Secret:
@@ -75,14 +89,26 @@ class {{ class_name }}(ops.CharmBase):
             )
 
     def _on_secret_rotate(self, event: ops.SecretRotateEvent):
-        """Handle secret-rotate event — generate a fresh workload password."""
+        """Handle secret-rotate event — the rotation policy says it's time for a new password."""
         if event.secret.label == APP_SECRET_LABEL:
-            event.secret.set_content({"password": secrets.token_hex(32)})
+            self._set_new_password(event.secret)
 
     def _on_secret_expired(self, event: ops.SecretExpiredEvent):
-        """Handle secret-expired event — remove the expired revision."""
+        """Handle secret-expired event — the current password must not be used any more."""
         if event.secret.label == APP_SECRET_LABEL:
-            event.secret.remove_revision(event.revision)
+            self._set_new_password(event.secret)
+
+    def _set_new_password(self, secret: ops.Secret) -> None:
+        """Add a new revision of the app-managed workload password."""
+        # Don't remove the old revision here: other units might still be using it.
+        # Juju emits secret-remove once no unit is tracking it any more.
+        secret.set_content({"password": secrets.token_hex(32)})
+
+    def _on_secret_remove(self, event: ops.SecretRemoveEvent):
+        """Handle secret-remove event — no unit is using this revision any more."""
+        # Without this, every rotation leaves another revision behind.
+        if event.secret.label == APP_SECRET_LABEL:
+            event.remove_revision()
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/charmcraft/templates/init-machine/src/charm.py.j2
+++ b/charmcraft/templates/init-machine/src/charm.py.j2
@@ -5,6 +5,8 @@
 """Charm the application."""
 
 import logging
+import secrets
+from datetime import timedelta
 
 import ops
 
@@ -12,6 +14,8 @@ import ops
 import {{ workload_module }}
 
 logger = logging.getLogger(__name__)
+
+APP_SECRET_LABEL = "workload-password"  # Label for the app-managed workload secret.
 
 
 class {{ class_name }}(ops.CharmBase):
@@ -21,6 +25,9 @@ class {{ class_name }}(ops.CharmBase):
         super().__init__(framework)
         framework.observe(self.on.install, self._on_install)
         framework.observe(self.on.start, self._on_start)
+        framework.observe(self.on.config_changed, self._on_config_changed)
+        framework.observe(self.on.secret_rotate, self._on_secret_rotate)
+        framework.observe(self.on.secret_expired, self._on_secret_expired)
 
     def _on_install(self, event: ops.InstallEvent):
         """Install the workload on the machine."""
@@ -33,7 +40,49 @@ class {{ class_name }}(ops.CharmBase):
         version = {{ workload_module }}.get_version()
         if version is not None:
             self.unit.set_workload_version(version)
+        # Create the app-managed workload secret on first start (leader only).
+        if self.unit.is_leader():
+            self._ensure_app_secret()
         self.unit.status = ops.ActiveStatus()
+
+    def _on_config_changed(self, event: ops.ConfigChangedEvent):
+        """Handle config-changed event — resolve the user-provided api-token secret."""
+        api_token_id = self.config.get("api-token")
+        if not api_token_id:
+            return
+        try:
+            secret = self.model.get_secret(id=api_token_id)
+            content = secret.get_content(refresh=True)
+            token = content.get("token", "")
+            # Use 'token' to configure your workload, for example:
+            # {{ workload_module }}.configure(api_token=token)
+            logger.info("api-token resolved (%d chars); reconfiguring workload", len(token))
+        except ops.SecretNotFoundError:
+            self.unit.status = ops.BlockedStatus("api-token secret not found or not granted")
+            return
+        self.unit.status = ops.ActiveStatus()
+
+    def _ensure_app_secret(self) -> ops.Secret:
+        """Get or create the app-managed workload password (idempotent, leader only)."""
+        try:
+            return self.model.get_secret(label=APP_SECRET_LABEL)
+        except ops.SecretNotFoundError:
+            return self.app.add_secret(
+                {"password": secrets.token_hex(32)},
+                label=APP_SECRET_LABEL,
+                rotate=ops.SecretRotate.MONTHLY,
+                expire=timedelta(days=90),
+            )
+
+    def _on_secret_rotate(self, event: ops.SecretRotateEvent):
+        """Handle secret-rotate event — generate a fresh workload password."""
+        if event.secret.label == APP_SECRET_LABEL:
+            event.secret.set_content({"password": secrets.token_hex(32)})
+
+    def _on_secret_expired(self, event: ops.SecretExpiredEvent):
+        """Handle secret-expired event — remove the expired revision."""
+        if event.secret.label == APP_SECRET_LABEL:
+            event.secret.remove_revision(event.revision)
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/charmcraft/templates/init-machine/src/charm.py.j2
+++ b/charmcraft/templates/init-machine/src/charm.py.j2
@@ -4,9 +4,9 @@
 
 """Charm the application."""
 
+import datetime
 import logging
 import secrets
-from datetime import timedelta
 
 import ops
 
@@ -85,7 +85,7 @@ class {{ class_name }}(ops.CharmBase):
                 {"password": secrets.token_hex(32)},
                 label=APP_SECRET_LABEL,
                 rotate=ops.SecretRotate.MONTHLY,
-                expire=timedelta(days=90),
+                expire=datetime.timedelta(days=90),
             )
 
     def _on_secret_rotate(self, event: ops.SecretRotateEvent):

--- a/charmcraft/templates/init-machine/tests/integration/test_charm.py.j2
+++ b/charmcraft/templates/init-machine/tests/integration/test_charm.py.j2
@@ -9,7 +9,6 @@
 
 import logging
 import pathlib
-import subprocess
 
 import jubilant
 import pytest
@@ -25,29 +24,33 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
 
 
 def test_app_managed_secret_created(juju: jubilant.Juju):
-    """Check that the app-managed workload-password secret is visible after deployment."""
-    # The charm creates this secret on start (leader unit).
-    # 'juju list-secrets' shows all secrets the current model user can see.
-    result = subprocess.check_output(["juju", "list-secrets", "--format=yaml"], text=True)
-    assert "workload-password" in result, (
+    """Check that the charm created the app-managed workload password on start."""
+    labels = [secret.label for secret in juju.secrets()]
+    assert "workload-password" in labels, (
         "Expected the charm to create a 'workload-password' app secret on start. "
         "Check that the leader unit ran the start hook successfully."
     )
 
 
 def test_user_secret(juju: jubilant.Juju):
-    """Test that a user-provided api-token secret is resolved by the charm."""
-    # Create a user secret with a 'token' key and set it as config.
-    secret_uri = subprocess.check_output(
-        ["juju", "add-secret", "test-api-token", "token=testvalue123"],
-        text=True,
-    ).strip()
-    subprocess.check_call(["juju", "grant-secret", secret_uri, "{{ name }}"])
+    """Test that the charm resolves a user-provided api-token secret."""
+    # Create a user secret with a 'token' key, grant the charm access, and
+    # point the charm at it.
+    secret_uri = juju.add_secret("test-api-token", {"token": "shortvalue"})
+    juju.grant_secret(secret_uri, "{{ name }}")
     juju.config("{{ name }}", {"api-token": secret_uri})
     juju.wait(jubilant.all_active)
 
-    status = juju.status()
-    assert status.apps["{{ name }}"].is_active
+    # The charm logs the length of the token it resolved.
+    assert "api-token resolved (10 chars)" in juju.debug_log()
+
+    # Act — add a new revision of the same secret. Juju notifies the charm with
+    # a secret-changed event, and the charm re-reads the content.
+    juju.update_secret(secret_uri, {"token": "a-much-longer-token-value"})
+    juju.wait(jubilant.all_active)
+
+    # Assert — the charm picked up the new revision, not the original one.
+    assert "api-token resolved (25 chars)" in juju.debug_log()
 
     # Clean up: reset the config option so subsequent tests start clean.
     juju.config("{{ name }}", reset=["api-token"])

--- a/charmcraft/templates/init-machine/tests/integration/test_charm.py.j2
+++ b/charmcraft/templates/init-machine/tests/integration/test_charm.py.j2
@@ -9,6 +9,7 @@
 
 import logging
 import pathlib
+import subprocess
 
 import jubilant
 import pytest
@@ -23,11 +24,40 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     juju.wait(jubilant.all_active)
 
 
+def test_app_managed_secret_created(juju: jubilant.Juju):
+    """Check that the app-managed workload-password secret is visible after deployment."""
+    # The charm creates this secret on start (leader unit).
+    # 'juju list-secrets' shows all secrets the current model user can see.
+    result = subprocess.check_output(["juju", "list-secrets", "--format=yaml"], text=True)
+    assert "workload-password" in result, (
+        "Expected the charm to create a 'workload-password' app secret on start. "
+        "Check that the leader unit ran the start hook successfully."
+    )
+
+
+def test_user_secret(juju: jubilant.Juju):
+    """Test that a user-provided api-token secret is resolved by the charm."""
+    # Create a user secret with a 'token' key and set it as config.
+    secret_uri = subprocess.check_output(
+        ["juju", "add-secret", "test-api-token", "token=testvalue123"],
+        text=True,
+    ).strip()
+    subprocess.check_call(["juju", "grant-secret", secret_uri, "{{ name }}"])
+    juju.config("{{ name }}", {"api-token": secret_uri})
+    juju.wait(jubilant.all_active)
+
+    status = juju.status()
+    assert status.apps["{{ name }}"].is_active
+
+    # Clean up: reset the config option so subsequent tests start clean.
+    juju.config("{{ name }}", reset=["api-token"])
+
+
 # If you implement {{ workload_module }}.get_version in the charm source,
 # remove the @pytest.mark.skip line to enable this test.
 # Alternatively, remove this test if you don't need it.
 @pytest.mark.skip(reason="{{ workload_module }}.get_version is not implemented")
-def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
+def test_workload_version_is_set(juju: jubilant.Juju):
     """Check that the correct version of the workload is running."""
     version = juju.status().apps["{{ name }}"].version
     assert version == "3.14"  # Replace 3.14 by the expected version of the workload.

--- a/charmcraft/templates/init-machine/tests/integration/test_charm.py.j2
+++ b/charmcraft/templates/init-machine/tests/integration/test_charm.py.j2
@@ -23,7 +23,7 @@ def test_deploy(charm: pathlib.Path, juju: jubilant.Juju):
     juju.wait(jubilant.all_active)
 
 
-def test_app_managed_secret_created(juju: jubilant.Juju):
+def test_app_managed_secret_created(charm: pathlib.Path, juju: jubilant.Juju):
     """Check that the charm created the app-managed workload password on start."""
     labels = [secret.label for secret in juju.secrets()]
     assert "workload-password" in labels, (
@@ -32,7 +32,7 @@ def test_app_managed_secret_created(juju: jubilant.Juju):
     )
 
 
-def test_user_secret(juju: jubilant.Juju):
+def test_user_secret(charm: pathlib.Path, juju: jubilant.Juju):
     """Test that the charm resolves a user-provided api-token secret."""
     # Create a user secret with a 'token' key, grant the charm access, and
     # point the charm at it.
@@ -60,7 +60,7 @@ def test_user_secret(juju: jubilant.Juju):
 # remove the @pytest.mark.skip line to enable this test.
 # Alternatively, remove this test if you don't need it.
 @pytest.mark.skip(reason="{{ workload_module }}.get_version is not implemented")
-def test_workload_version_is_set(juju: jubilant.Juju):
+def test_workload_version_is_set(charm: pathlib.Path, juju: jubilant.Juju):
     """Check that the correct version of the workload is running."""
     version = juju.status().apps["{{ name }}"].version
     assert version == "3.14"  # Replace 3.14 by the expected version of the workload.

--- a/charmcraft/templates/init-machine/tests/unit/test_charm.py.j2
+++ b/charmcraft/templates/init-machine/tests/unit/test_charm.py.j2
@@ -6,7 +6,7 @@
 import pytest
 from ops import testing
 
-from charm import {{ class_name }}
+from charm import APP_SECRET_LABEL, {{ class_name }}
 
 
 def mock_get_version():
@@ -24,3 +24,129 @@ def test_start(monkeypatch: pytest.MonkeyPatch):
     # Assert:
     assert state_out.workload_version is not None
     assert state_out.unit_status == testing.ActiveStatus()
+
+
+def test_start_creates_app_secret(monkeypatch: pytest.MonkeyPatch):
+    """Test that the charm creates an app-managed workload secret on start (leader)."""
+    # Arrange:
+    ctx = testing.Context({{ class_name }})
+    monkeypatch.setattr("charm.{{ workload_module }}.get_version", mock_get_version)
+    state_in = testing.State(leader=True)
+
+    # Act:
+    state_out = ctx.run(ctx.on.start(), state_in)
+
+    # Assert — the app-owned secret should appear in the output state with a 'password' key:
+    app_secrets = [s for s in state_out.secrets if s.label == APP_SECRET_LABEL]
+    assert len(app_secrets) == 1
+    assert app_secrets[0].latest_content is not None
+    assert "password" in app_secrets[0].latest_content
+
+
+def test_start_app_secret_already_exists(monkeypatch: pytest.MonkeyPatch):
+    """Test that start is idempotent when the app secret already exists."""
+    # Arrange:
+    ctx = testing.Context({{ class_name }})
+    monkeypatch.setattr("charm.{{ workload_module }}.get_version", mock_get_version)
+    existing_secret = testing.Secret(
+        tracked_content={"password": "existing-password"},
+        label=APP_SECRET_LABEL,
+        owner="app",
+    )
+    state_in = testing.State(leader=True, secrets={existing_secret})
+
+    # Act:
+    state_out = ctx.run(ctx.on.start(), state_in)
+
+    # Assert — the existing secret is still present; no extra secret was created:
+    app_secrets = [s for s in state_out.secrets if s.label == APP_SECRET_LABEL]
+    assert len(app_secrets) == 1
+
+
+def test_config_changed_with_api_token():
+    """Test that config-changed resolves a user-provided secret and goes active."""
+    # Arrange:
+    ctx = testing.Context({{ class_name }})
+    secret = testing.Secret(
+        tracked_content={"token": "my-secret-api-token"},
+        id="secret:abcdef123456",
+        owner=None,  # user-owned secret (not app- or unit-owned)
+    )
+    state_in = testing.State(
+        secrets={secret},
+        config={"api-token": secret.id},
+    )
+
+    # Act:
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    # Assert:
+    assert state_out.unit_status == testing.ActiveStatus()
+
+
+def test_config_changed_api_token_not_found():
+    """Test that config-changed blocks when the secret URI is not accessible."""
+    # Arrange:
+    ctx = testing.Context({{ class_name }})
+    state_in = testing.State(
+        config={"api-token": "secret:doesnotexist"},
+        # No matching secret in state — simulates the secret not being granted.
+    )
+
+    # Act:
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    # Assert:
+    assert isinstance(state_out.unit_status, testing.BlockedStatus)
+
+
+def test_config_changed_no_token():
+    """Test that config-changed without api-token set does nothing."""
+    # Arrange:
+    ctx = testing.Context({{ class_name }})
+    state_in = testing.State()
+
+    # Act:
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    # Assert — status unchanged (charm hasn't done anything yet):
+    assert not isinstance(state_out.unit_status, testing.BlockedStatus)
+
+
+def test_secret_rotate():
+    """Test that secret-rotate generates a new revision of the workload password."""
+    # Arrange:
+    ctx = testing.Context({{ class_name }})
+    secret = testing.Secret(
+        tracked_content={"password": "old-password"},
+        label=APP_SECRET_LABEL,
+        owner="app",
+    )
+    state_in = testing.State(secrets={secret}, leader=True)
+
+    # Act:
+    state_out = ctx.run(ctx.on.secret_rotate(secret), state_in)
+
+    # Assert — a new revision with a different password should have been added:
+    out_secret = state_out.get_secret(label=APP_SECRET_LABEL)
+    assert out_secret.latest_content is not None
+    assert "password" in out_secret.latest_content
+    assert out_secret.latest_content["password"] != "old-password"
+
+
+def test_secret_expired():
+    """Test that secret-expired removes the expired revision without error."""
+    # Arrange:
+    ctx = testing.Context({{ class_name }})
+    secret = testing.Secret(
+        tracked_content={"password": "current-password"},
+        label=APP_SECRET_LABEL,
+        owner="app",
+    )
+    state_in = testing.State(secrets={secret}, leader=True)
+
+    # Act — simulate the tracked revision expiring:
+    state_out = ctx.run(ctx.on.secret_expired(secret, revision=1), state_in)
+
+    # Assert — the charm should not have errored or blocked:
+    assert not isinstance(state_out.unit_status, testing.BlockedStatus)

--- a/charmcraft/templates/init-machine/tests/unit/test_charm.py.j2
+++ b/charmcraft/templates/init-machine/tests/unit/test_charm.py.j2
@@ -6,7 +6,7 @@
 import pytest
 from ops import testing
 
-from charm import APP_SECRET_LABEL, {{ class_name }}
+from charm import API_TOKEN_LABEL, APP_SECRET_LABEL, {{ class_name }}
 
 
 def mock_get_version():
@@ -69,7 +69,6 @@ def test_config_changed_with_api_token():
     ctx = testing.Context({{ class_name }})
     secret = testing.Secret(
         tracked_content={"token": "my-secret-api-token"},
-        id="secret:abcdef123456",
         owner=None,  # user-owned secret (not app- or unit-owned)
     )
     state_in = testing.State(
@@ -89,7 +88,7 @@ def test_config_changed_api_token_not_found():
     # Arrange:
     ctx = testing.Context({{ class_name }})
     state_in = testing.State(
-        config={"api-token": "secret:doesnotexist"},
+        config={"api-token": "secret:doesnotexist00000000"},
         # No matching secret in state — simulates the secret not being granted.
     )
 
@@ -135,11 +134,11 @@ def test_secret_rotate():
 
 
 def test_secret_expired():
-    """Test that secret-expired removes the expired revision without error."""
+    """Test that secret-expired replaces the expired password with a new revision."""
     # Arrange:
     ctx = testing.Context({{ class_name }})
     secret = testing.Secret(
-        tracked_content={"password": "current-password"},
+        tracked_content={"password": "expired-password"},
         label=APP_SECRET_LABEL,
         owner="app",
     )
@@ -148,5 +147,49 @@ def test_secret_expired():
     # Act — simulate the tracked revision expiring:
     state_out = ctx.run(ctx.on.secret_expired(secret, revision=1), state_in)
 
-    # Assert — the charm should not have errored or blocked:
-    assert not isinstance(state_out.unit_status, testing.BlockedStatus)
+    # Assert — a new revision should have been added, not the old one removed:
+    out_secret = state_out.get_secret(label=APP_SECRET_LABEL)
+    assert out_secret.latest_content is not None
+    assert out_secret.latest_content["password"] != "expired-password"
+
+
+def test_secret_changed_new_api_token_revision():
+    """Test that the charm picks up a new revision of the user-provided api-token."""
+    # Arrange:
+    ctx = testing.Context({{ class_name }})
+    secret = testing.Secret(
+        tracked_content={"token": "old-api-token"},
+        latest_content={"token": "new-api-token"},
+        label=API_TOKEN_LABEL,
+        owner=None,  # user-owned secret (not app- or unit-owned)
+    )
+    state_in = testing.State(secrets={secret}, config={"api-token": secret.id})
+
+    # Act:
+    state_out = ctx.run(ctx.on.secret_changed(secret), state_in)
+
+    # Assert — the charm refreshed, so it now tracks the latest revision:
+    out_secret = state_out.get_secret(label=API_TOKEN_LABEL)
+    assert out_secret.tracked_content == {"token": "new-api-token"}
+    assert state_out.unit_status == testing.ActiveStatus()
+
+
+def test_secret_remove():
+    """Test that secret-remove cleans up a revision that no unit is using."""
+    # Arrange — rotate twice, so that revision 2 is neither the oldest revision
+    # nor the newest one:
+    ctx = testing.Context({{ class_name }})
+    secret = testing.Secret(
+        tracked_content={"password": "first-password"},
+        label=APP_SECRET_LABEL,
+        owner="app",
+    )
+    state = testing.State(secrets={secret}, leader=True)
+    for _ in range(2):
+        state = ctx.run(ctx.on.secret_rotate(state.get_secret(label=APP_SECRET_LABEL)), state)
+
+    # Act — Juju reports that revision 2 is no longer tracked by any unit:
+    ctx.run(ctx.on.secret_remove(state.get_secret(label=APP_SECRET_LABEL), revision=2), state)
+
+    # Assert — the charm asked Juju to remove that revision:
+    assert ctx.removed_secret_revisions == [2]

--- a/docs/release-notes/charmcraft-4.5.rst
+++ b/docs/release-notes/charmcraft-4.5.rst
@@ -54,6 +54,22 @@ Minor features
 Charmcraft 4.5 brings the following minor changes.
 
 
+Secrets handling in the machine and Kubernetes profiles
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Charms created with the ``machine`` and ``kubernetes`` profiles now demonstrate both
+sides of Juju secrets.
+
+For a user-provided secret, the charm declares an ``api-token`` config option of type
+``secret``, resolves it, and re-reads it when the operator adds a new revision.
+
+For an app-managed secret, the leader creates a workload password with a rotation
+policy and an expiry, replaces it when Juju asks for rotation or reports expiry, and
+removes old revisions once no unit is using them.
+
+Both profiles scaffold unit and integration tests for this behaviour.
+
+
 <Feature A>
 ~~~~~~~~~~~
 


### PR DESCRIPTION
Extends both the `kubernetes` and `machine` profiles so that `charmcraft init` scaffolds a charm that handles Juju secrets from both sides, with unit and integration tests for it.

The profile is a strong signal to human and agentic charmers for best practices. Secrets are a good candidate for that signal because they are easy to get half-right: reading an observed secret once on `config-changed` looks correct until the operator adds a new revision and nothing happens, and rotating an owned secret looks correct until revisions pile up because nothing removes them. Both failures are silent, so the profile handles the full event set rather than the two events that are enough for a demo.

A charm also meets secrets in two roles that need different code — it observes secrets an operator grants it, and it owns secrets it generates for its workload. A charm author who has only seen one usually writes the other incorrectly.

### Changes

Both profiles in `charmcraft.yaml.j2`:

Adds an `api-token` config option of `type: secret`, with a description giving the operator the three commands they need (`juju add-secret`, `juju grant-secret`, `juju config`).

In both profiles, the observed secret:

`config-changed` and `secret-changed` share one `_configure_api_token()`, which fetches with `model.get_secret(id=..., label=API_TOKEN_LABEL)` and reads with `get_content(refresh=True)`. Attaching the label is what lets the `secret-changed` handler recognise the secret, since the event carries the label rather than the config value. A secret that isn't granted, or has gone away, leaves the unit blocked.

In both profiles, the app-managed secret:

The leader creates a workload password on `start` (machine) or `pebble-ready` (kubernetes), with monthly rotation and a 90 day expiry; creation is looked up by label first, so it's idempotent. `secret-rotate` and `secret-expired` both add a new revision — expiry doesn't remove the expiring revision, because that's the latest one and other units may still be reading it. `secret-remove` does the cleanup, once Juju reports that no unit is tracking a revision.